### PR TITLE
Change handle accessor to slice from list for strings

### DIFF
--- a/src/dolomite_base/_utils_string.py
+++ b/src/dolomite_base/_utils_string.py
@@ -28,7 +28,7 @@ def save_fixed_length_strings(handle: h5py.Group, name: str, x: List[str]) -> h5
 
 
 def load_string_vector_from_hdf5(handle: h5py.Dataset) -> List[str]:
-    output = list(handle)
+    output = handle[:]
     if len(output) and isinstance(output[0], bytes):
         for i, x in enumerate(output):
             output[i] = x.decode("UTF-8")

--- a/src/dolomite_base/_utils_string.py
+++ b/src/dolomite_base/_utils_string.py
@@ -29,9 +29,9 @@ def save_fixed_length_strings(handle: h5py.Group, name: str, x: List[str]) -> h5
 
 def load_string_vector_from_hdf5(handle: h5py.Dataset) -> List[str]:
     output = handle[:]
-    if len(output) and isinstance(output[0], bytes):
+    if len(output):
         for i, x in enumerate(output):
-            output[i] = x.decode("UTF-8")
+            output[i] = x.decode("UTF-8") if isinstance(x, bytes) else x
     return output
 
 

--- a/src/dolomite_base/_utils_string.py
+++ b/src/dolomite_base/_utils_string.py
@@ -1,5 +1,6 @@
 from typing import List
 import h5py
+import numpy
 
 
 def save_fixed_length_strings(handle: h5py.Group, name: str, x: List[str]) -> h5py.Dataset:
@@ -19,7 +20,7 @@ def save_fixed_length_strings(handle: h5py.Group, name: str, x: List[str]) -> h5
         ``x`` is saved into the group as a fixed-length string dataset,
         and a NumPy dataset handle is returned.
     """
-    tmp = [ y.encode("UTF8") for y in x ]
+    tmp = [ y.encode("UTF-8") for y in x ]
     maxed = 1
     for b in tmp:
         if len(b) > maxed:
@@ -29,14 +30,20 @@ def save_fixed_length_strings(handle: h5py.Group, name: str, x: List[str]) -> h5
 
 def load_string_vector_from_hdf5(handle: h5py.Dataset) -> List[str]:
     output = handle[:]
+
     if len(output):
-        for i, x in enumerate(output):
-            output[i] = x.decode("UTF-8") if not isinstance(x, str) else x
+        _output = []
+        for x in output:
+            _out = x
+            if isinstance(x, bytes) or isinstance(x, numpy.bytes_):
+                _out = x.decode("UTF-8") 
+            _output.append(_out)
+        output = _output
     return output
 
 
 def load_scalar_string_attribute_from_hdf5(handle, name: str) -> str:
     output = handle.attrs[name]
-    if isinstance(output, bytes):
+    if isinstance(output, bytes) or isinstance(output, numpy.bytes_):
         output = output.decode("UTF-8")
     return output

--- a/src/dolomite_base/_utils_string.py
+++ b/src/dolomite_base/_utils_string.py
@@ -34,9 +34,7 @@ def load_string_vector_from_hdf5(handle: h5py.Dataset) -> List[str]:
     if len(output):
         _output = []
         for x in output:
-            _out = x
-            if isinstance(x, bytes) or isinstance(x, numpy.bytes_):
-                _out = x.decode("UTF-8") 
+            _out = x.decode("UTF-8") if isinstance(x, (bytes, numpy.bytes_)) else x
             _output.append(_out)
         output = _output
     return output
@@ -44,6 +42,6 @@ def load_string_vector_from_hdf5(handle: h5py.Dataset) -> List[str]:
 
 def load_scalar_string_attribute_from_hdf5(handle, name: str) -> str:
     output = handle.attrs[name]
-    if isinstance(output, bytes) or isinstance(output, numpy.bytes_):
+    if isinstance(output, (bytes, numpy.bytes_)):
         output = output.decode("UTF-8")
     return output

--- a/src/dolomite_base/_utils_string.py
+++ b/src/dolomite_base/_utils_string.py
@@ -31,7 +31,7 @@ def load_string_vector_from_hdf5(handle: h5py.Dataset) -> List[str]:
     output = handle[:]
     if len(output):
         for i, x in enumerate(output):
-            output[i] = x.decode("UTF-8") if isinstance(x, bytes) else x
+            output[i] = x.decode("UTF-8") if not isinstance(x, str) else x
     return output
 
 


### PR DESCRIPTION
`list(...)` takes forever compared to accessing the full slice and casting it to string

<img width="566" alt="image" src="https://github.com/ArtifactDB/dolomite-base/assets/399324/c194386e-c388-4b47-882f-031d12111ae0">
